### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'net.ltgt.apt' version '0.21'
-    id 'com.github.ben-manes.versions' version '0.36.0'
+    id 'com.github.ben-manes.versions' version '0.38.0'
     id 'net.researchgate.release' version '2.8.1'
 }
 
@@ -22,16 +22,16 @@ ext {
     }
 
     // Dependencies
-    reactor_bom_version = 'Dysprosium-SR14'
+    reactor_bom_version = '2020.0.5'
     servicer_version = '1.0.3'
     commons_codec_version = '1.12'
-    junit_version = '4.13.1'
+    junit_version = '4.13.2'
     logback_version = '1.3.0-alpha4'
 
-    caffeine_version = '2.8.6'
-    lettuce_version = '5.3.5.RELEASE'
-    jackson_version = '2.11.2'
-    commons_lang_version = '3.11'
+    caffeine_version = '2.9.0'
+    lettuce_version = '6.0.3.RELEASE'
+    jackson_version = '2.12.2'
+    commons_lang_version = '3.12.0'
 
     isJitpack = "true" == System.getenv("JITPACK")
     isRelease = !version.toString().endsWith('-SNAPSHOT')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
-version=3.1.6-SNAPSHOT
-discordJsonVersion=1.5.5
+version=3.2.0-SNAPSHOT
+discordJsonVersion=1.6.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Major:
Lettuce 6.0.3

Minor:
Reactor Bom 2020.0.5
Caffeine 2.9.0
Jackson 2.12.2
Commons Lang 3.12.0

Internal:
Versions Plugin 0.38.0
Junit 4.13.2
Gradle 6.8.3


Due to the major updates, and actually incompatible ABI in the redis store (which is the main motivation behind the PR), this also raises the snapshot version to 3.2.x