### PR TITLE
Lazily create Redis Client if none was set on Builder

### DIFF
--- a/redis/src/main/java/discord4j/store/redis/RedisStoreService.java
+++ b/redis/src/main/java/discord4j/store/redis/RedisStoreService.java
@@ -134,7 +134,7 @@ public class RedisStoreService implements StoreService {
      */
     public static class Builder {
 
-        private RedisClient redisClient = defaultClient();
+        private RedisClient redisClient;
         private RedisCodec<byte[], byte[]> redisCodec = byteArrayCodec();
         private String keyPrefix = RedisStoreDefaults.keyPrefix();
         private RedisSerializerFactory keySerializerFactory = stringKeySerializerFactory();
@@ -214,7 +214,10 @@ public class RedisStoreService implements StoreService {
          * @return a {@link RedisStoreService}
          */
         public RedisStoreService build() {
-            return new RedisStoreService(redisClient, redisCodec, keyPrefix,
+            if (this.redisClient == null) {
+                this.redisClient = defaultClient();
+            }
+            return new RedisStoreService(this.redisClient, redisCodec, keyPrefix,
                 keySerializerFactory, valueSerializerFactory, sharedConnection);
         }
     }


### PR DESCRIPTION
I usually get this warning at start, because I configure the client in the redis store manually:

```
2021-05-02 19:21:28.632 []  WARN 11160 --- [      Finalizer] i.l.c.resource.DefaultClientResources    : io.lettuce.core.resource.DefaultClientResources was not shut down properly, shutdown() was not called before it's garbage-collected. Call shutdown() or shutdown(long,long,TimeUnit) 
```

```kotlin
	private fun redisStoreService(): StoreService {
		val redisClient = RedisClient.create(databaseConfig.entityCacheRedisUrl)
		return RedisStoreService.builder()
			.redisClient(redisClient)
			.build()
	}
```

The Builder eagerly creates the default Redis Client, which gets overwritten by my custom one, which results in the above warning logged when eventually the defaut Redis Client is GCed.
This PR changes the Builder to lazily create the default Redis Client when it actually builds the store and none has been set.