### PR TITLE
Add jackson time compatibility module for guild schedule events

### DIFF
--- a/redis/build.gradle
+++ b/redis/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     api "io.lettuce:lettuce-core:$lettuce_version"
     implementation "com.discord4j:discord-json-api:$discordJsonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jackson_version"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     annotationProcessor "com.austinv11.servicer:Servicer:$servicer_version"
 
     testImplementation project(':tck')

--- a/redis/src/main/java/discord4j/store/redis/RedisStoreDefaults.java
+++ b/redis/src/main/java/discord4j/store/redis/RedisStoreDefaults.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import discord4j.discordjson.possible.PossibleFilter;
 import discord4j.discordjson.possible.PossibleModule;
 import discord4j.store.api.util.LongLongTuple2;
@@ -147,6 +148,7 @@ public class RedisStoreDefaults {
         ObjectMapper mapper = new ObjectMapper()
                 .registerModule(new PossibleModule())
                 .registerModule(new Jdk8Module())
+                .registerModule(new JavaTimeModule())
                 .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
                 .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.PUBLIC_ONLY)
                 .setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY)


### PR DESCRIPTION
I have added the fasterxml jackson jsr310 time conversion module because of following error while receiving GuildScheduledEvent using this store implementation:

<details><summary>Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.Instant` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: discord4j.discordjson.json.ImmutableGuildScheduledEventData["scheduled_start_time"])</summary>
<p>


**Full Stacktrace:**

2024-01-17 15:08:34.878 ERROR 2572 --- [ioEventLoop-6-1] d.gateway.state.DispatchStoreLayer       : Error when executing store action on dispatch GuildScheduledEventUpdate{scheduledEvent=GuildScheduledEventData{id=123, guildId=456, channelId=Optional.empty, creatorId=Possible{Optional[789]}, name=blub, description=Possible{Optional[]}, scheduledStartTime=2024-01-17T15:00:00.500Z, scheduledEndTime=2024-01-17T17:00:00.500Z, privacyLevel=2, status=1, entityType=3, entityId=Optional.empty, entityMetadata=GuildScheduledEventEntityMetadataData{location=Possible{bla2}}, creator=Possible.absent, userCount=Possible.absent, image=Possible{Optional.empty}}}

discord4j.store.redis.SerializationException: Unable to write JSON: GuildScheduledEventData{id=123, guildId=456, channelId=Optional.empty, creatorId=Possible{Optional[789]}, name=blub, description=Possible{Optional[]}, scheduledStartTime=2024-01-17T15:00:00.500Z, scheduledEndTime=2024-01-17T17:00:00.500Z, privacyLevel=2, status=1, entityType=3, entityId=Optional.empty, entityMetadata=GuildScheduledEventEntityMetadataData{location=Possible{bla2}}, creator=Possible.absent, userCount=Possible.absent, image=Possible{Optional.empty}}
	at discord4j.store.redis.JacksonRedisSerializer.serialize(JacksonRedisSerializer.java:46) ~[stores-redis-3.2.2.jar:3.2.2]
	at discord4j.store.redis.RedisStore.lambda$save$0(RedisStore.java:57) ~[stores-redis-3.2.2.jar:3.2.2]
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:45) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.subscribeNext(MonoIgnoreThen.java:264) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:51) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4512) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onComplete(FluxSwitchIfEmpty.java:82) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onComplete(MonoFlatMap.java:189) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:144) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.MonoNext$NextSubscriber.onComplete(MonoNext.java:102) ~[reactor-core-3.6.0.jar:3.6.0]
	at reactor.core.publisher.MonoNext$NextSubscriber.onComplete(MonoNext.java:102) ~[reactor-core-3.6.0.jar:3.6.0]
	at io.lettuce.core.RedisPublisher$ImmediateSubscriber.onComplete(RedisPublisher.java:900) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.RedisPublisher$State.onAllDataRead(RedisPublisher.java:702) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.RedisPublisher$State$3.read(RedisPublisher.java:612) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.RedisPublisher$State$3.onDataAvailable(RedisPublisher.java:569) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.RedisPublisher$RedisSubscription.onDataAvailable(RedisPublisher.java:326) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.RedisPublisher$RedisSubscription.onAllDataRead(RedisPublisher.java:341) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.RedisPublisher$SubscriptionCommand.doOnComplete(RedisPublisher.java:782) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.protocol.CommandWrapper.complete(CommandWrapper.java:65) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.protocol.CommandWrapper.complete(CommandWrapper.java:63) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.protocol.CommandHandler.complete(CommandHandler.java:746) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.protocol.CommandHandler.decode(CommandHandler.java:681) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.lettuce.core.protocol.CommandHandler.channelRead(CommandHandler.java:598) ~[lettuce-core-6.2.7.RELEASE.jar:6.2.7.RELEASE]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.101.Final.jar:4.1.101.Final]
	at java.base/java.lang.Thread.run(Thread.java:857) ~[na:na]
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.Instant` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: discord4j.discordjson.json.ImmutableGuildScheduledEventData["scheduled_start_time"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1308) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.impl.UnsupportedTypeSerializer.serialize(UnsupportedTypeSerializer.java:35) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:772) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:479) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:318) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4719) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsBytes(ObjectMapper.java:3987) ~[jackson-databind-2.15.3.jar:2.15.3]
	at discord4j.store.redis.JacksonRedisSerializer.serialize(JacksonRedisSerializer.java:44) ~[stores-redis-3.2.2.jar:3.2.2]
	... 38 common frames omitted
</p>
</details> 