### PR TITLE
Add jackson time compatibility module to Redis Store (#14)

### DIFF
--- a/redis/build.gradle
+++ b/redis/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     api "io.lettuce:lettuce-core:$lettuce_version"
     implementation "com.discord4j:discord-json-api:$discordJsonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jackson_version"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     annotationProcessor "com.austinv11.servicer:Servicer:$servicer_version"
 
     testImplementation project(':tck')

--- a/redis/src/main/java/discord4j/store/redis/RedisStoreDefaults.java
+++ b/redis/src/main/java/discord4j/store/redis/RedisStoreDefaults.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import discord4j.discordjson.possible.PossibleFilter;
 import discord4j.discordjson.possible.PossibleModule;
 import discord4j.store.api.util.LongLongTuple2;
@@ -147,6 +148,7 @@ public class RedisStoreDefaults {
         ObjectMapper mapper = new ObjectMapper()
                 .registerModule(new PossibleModule())
                 .registerModule(new Jdk8Module())
+                .registerModule(new JavaTimeModule())
                 .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
                 .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.PUBLIC_ONLY)
                 .setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY)


### PR DESCRIPTION
This PR was make by @dominoxp in #14 
But based in time and recent changes need remake the PR for run the correct CI Tests